### PR TITLE
fix/부동소수점 오차로 인한 hydration mismatch 수정

### DIFF
--- a/src/components/CircularTimeline.tsx
+++ b/src/components/CircularTimeline.tsx
@@ -15,20 +15,23 @@ const CircularTimeline = ({ activityList }: CircularTimelineProps) => {
   const cx = size / 2;
   const cy = size / 2;
 
-  const [currentMinutes, setCurrentMinutes] = useState(getMinutes(new Date()));
-  const runnerPos = polarToCartesian(currentMinutes, r + 15);
+  const [currentMinutes, setCurrentMinutes] = useState<number | null>(null);
+  const runnerPosition =
+    currentMinutes !== null ? polarToCartesian(currentMinutes, r + 15) : null;
 
   useEffect(() => {
+    // 시간 -> 분
+    function getMinutes(date: Date) {
+      return date.getHours() * 60 + date.getMinutes();
+    }
+    setCurrentMinutes(getMinutes(new Date()));
+
     const timer = setInterval(() => {
       setCurrentMinutes(getMinutes(new Date()));
     }, 60 * 1000); // 1분마다 업데이트
+
     return () => clearInterval(timer);
   }, []);
-
-  // 시간 -> 분
-  function getMinutes(date: Date) {
-    return date.getHours() * 60 + date.getMinutes();
-  }
 
   // "HH:MM" -> 분
   function parseTime(t: string) {
@@ -39,9 +42,13 @@ const CircularTimeline = ({ activityList }: CircularTimelineProps) => {
   // 분 -> 좌표
   function polarToCartesian(minutes: number, radius: number) {
     const angle = ((minutes / 1440) * 360 - 90) * (Math.PI / 180);
+
+    const x = cx + radius * Math.cos(angle);
+    const y = cy + radius * Math.sin(angle);
+
     return {
-      x: cx + radius * Math.cos(angle),
-      y: cy + radius * Math.sin(angle),
+      x: Number(x.toFixed(4)),
+      y: Number(y.toFixed(4)),
       angle,
     };
   }
@@ -115,20 +122,22 @@ const CircularTimeline = ({ activityList }: CircularTimelineProps) => {
       })}
 
       {/* 현재 시간 표시 */}
-      <g
-        transform={`rotate(${(runnerPos.angle * 180) / Math.PI + 90}, ${
-          runnerPos.x
-        }, ${runnerPos.y})`}
-      >
-        <foreignObject
-          x={runnerPos.x - 30}
-          y={runnerPos.y - 30}
-          width={60}
-          height={60}
+      {runnerPosition && (
+        <g
+          transform={`rotate(${(runnerPosition.angle * 180) / Math.PI + 90}, ${
+            runnerPosition.x
+          }, ${runnerPosition.y})`}
         >
-          <Lottie animationData={running} loop />
-        </foreignObject>
-      </g>
+          <foreignObject
+            x={runnerPosition.x - 30}
+            y={runnerPosition.y - 30}
+            width={60}
+            height={60}
+          >
+            <Lottie animationData={running} loop />
+          </foreignObject>
+        </g>
+      )}
     </svg>
   );
 };

--- a/src/components/Running.tsx
+++ b/src/components/Running.tsx
@@ -1,8 +1,0 @@
-import Lottie from "lottie-react";
-import running from "../../public/lottie/running.json";
-
-function Running() {
-  return <Lottie animationData={running} loop />;
-}
-
-export default Running;


### PR DESCRIPTION
## 📌 작업
- 타임라인 현재 시간을 나타낼 때, 서버와 클라이언트가 mismatch 되는 버그 수정
## 🚀 작업 상세
- 현재 시간이 부동소수점으로 인해 서버와 클라이언트 오차가 발생
- 현재 시간을 useEffect 안에서 계산하여 클라이언트에서만 실행하도록 변경
- 좌표를 나타낼 때, 소수점 4자리까지 고정하여 부동소수점 차이 해결
- 러너 애니메이션을 러너포지션이 있을때만 보이도록 수정 (클라이언트에서만 보이기 때문에 새로고침 시 잠시 사라짐)
