### PR TITLE
feat/활동 통계 기능 구현

### DIFF
--- a/src/app/stats/components/LogStats.tsx
+++ b/src/app/stats/components/LogStats.tsx
@@ -1,0 +1,104 @@
+"use client";
+
+import { useMemo } from "react";
+import { useActivityStore } from "@/stores/useActivityStore";
+import { parse, differenceInMinutes } from "date-fns";
+import { DAY_MINUTES, TIME_FMT } from "@/utils/constants";
+
+export default function LogStats() {
+  const { activityList } = useActivityStore();
+
+  const logs = useMemo(
+    () => activityList.filter((a) => a.source === "log" && !!a.endTime),
+    [activityList]
+  );
+
+  const totalMinutes = useMemo(
+    () =>
+      logs.reduce((acc, cur) => {
+        if (!cur.endTime) return acc;
+
+        const s = parse(cur.startTime, TIME_FMT, new Date());
+        const e = parse(cur.endTime, TIME_FMT, new Date());
+
+        return acc + differenceInMinutes(e, s);
+      }, 0),
+    [logs]
+  );
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, number>();
+    logs.forEach((log) => {
+      if (!log.endTime) return;
+
+      const mins = differenceInMinutes(
+        parse(log.endTime, TIME_FMT, new Date()),
+        parse(log.startTime, TIME_FMT, new Date())
+      );
+      if (mins <= 0) return;
+      map.set(log.activityName, (map.get(log.activityName) ?? 0) + mins);
+    });
+
+    return [...map.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([name, minutes]) => ({
+        name,
+        minutes,
+        percentOfDay: (minutes / DAY_MINUTES) * 100,
+        percentOfTotal: totalMinutes ? (minutes / totalMinutes) * 100 : 0,
+      }));
+  }, [logs, totalMinutes]);
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-bold">기록 통계</h2>
+
+      <div className="text-gray-700 font-medium mb-2">
+        총 사용 시간: {Math.floor(totalMinutes / 60)}시간 {totalMinutes % 60}분
+      </div>
+
+      {grouped.map((row) => (
+        <div
+          key={row.name}
+          className="p-3 border rounded-xl shadow-sm bg-white space-y-1"
+        >
+          {/* 첫 줄: 이름 + 총 시간 */}
+          <div className="flex justify-between items-center mb-1">
+            <span className="font-semibold">{row.name}</span>
+            <span className="text-sm text-gray-500">
+              {Math.floor(row.minutes / 60)}시간 {row.minutes % 60}분
+            </span>
+          </div>
+
+          {/* 둘째 줄: 24시간 대비 */}
+          <div className="flex items-center space-x-2">
+            <span className="text-xs text-blue-500 w-24">24시간 대비</span>
+            <div className="flex-1 h-3 bg-gray-200 rounded-full overflow-hidden">
+              <div
+                className="h-3 bg-blue-500"
+                style={{ width: `${row.percentOfDay}%` }}
+              />
+            </div>
+            <span className="text-xs text-blue-500 w-12 text-right">
+              {row.percentOfDay.toFixed(1)}%
+            </span>
+          </div>
+
+          {/* 셋째 줄: 전체 기록 대비 */}
+          <div className="flex items-center space-x-2">
+            <span className="text-xs text-green-500 w-24">전체 기록 대비</span>
+            <div className="flex-1 h-3 bg-gray-200 rounded-full overflow-hidden">
+              <div
+                className="h-3 bg-green-500"
+                style={{ width: `${row.percentOfTotal}%` }}
+              />
+            </div>
+            <span className="text-xs text-green-500 w-12 text-right">
+              {row.percentOfTotal.toFixed(1)}%
+            </span>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/app/stats/components/PlanStats.tsx
+++ b/src/app/stats/components/PlanStats.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useMemo } from "react";
+import { useActivityStore } from "@/stores/useActivityStore";
+import { parse, differenceInMinutes } from "date-fns";
+import { DAY_MINUTES, TIME_FMT } from "@/utils/constants";
+
+export default function PlanStats() {
+  const { activityList } = useActivityStore();
+
+  const plans = useMemo(
+    () => activityList.filter((a) => a.source === "plan"),
+    [activityList]
+  );
+
+  const totalMinutes = useMemo(
+    () =>
+      plans.reduce((acc, cur) => {
+        if (!cur.endTime) return acc;
+
+        const s = parse(cur.startTime, TIME_FMT, new Date());
+        const e = parse(cur.endTime, TIME_FMT, new Date());
+
+        return acc + differenceInMinutes(e, s);
+      }, 0),
+    [plans]
+  );
+
+  const grouped = useMemo(() => {
+    const map = new Map<string, number>();
+    plans.forEach((plan) => {
+      if (!plan.endTime) return;
+
+      const mins = differenceInMinutes(
+        parse(plan.endTime, TIME_FMT, new Date()),
+        parse(plan.startTime, TIME_FMT, new Date())
+      );
+      if (mins <= 0) return;
+      map.set(plan.activityName, (map.get(plan.activityName) ?? 0) + mins);
+    });
+
+    return [...map.entries()]
+      .sort((a, b) => b[1] - a[1])
+      .map(([name, minutes]) => ({
+        name,
+        minutes,
+        percentOfDay: (minutes / DAY_MINUTES) * 100,
+        percentOfTotal: totalMinutes ? (minutes / totalMinutes) * 100 : 0,
+      }));
+  }, [plans, totalMinutes]);
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-bold">계획 통계 (Plan)</h2>
+      <div className="text-gray-700 font-medium mb-2">
+        총 계획 시간: {Math.floor(totalMinutes / 60)}시간 {totalMinutes % 60}분
+      </div>
+
+      {grouped.map((row) => (
+        <div
+          key={row.name}
+          className="p-3 border rounded-xl shadow-sm bg-white space-y-1"
+        >
+          {/* 첫 줄: 이름 + 총 시간 */}
+          <div className="flex justify-between items-center">
+            <span className="font-semibold">{row.name}</span>
+            <span className="text-sm text-gray-500">
+              {Math.floor(row.minutes / 60)}시간 {row.minutes % 60}분
+            </span>
+          </div>
+
+          {/* 둘째 줄: 24시간 대비 */}
+          <div className="flex items-center space-x-2">
+            <span className="text-xs text-orange-500 w-24">24시간 대비</span>
+            <div className="flex-1 h-3 bg-gray-200 rounded-full overflow-hidden">
+              <div
+                className="h-3 bg-orange-500"
+                style={{ width: `${row.percentOfDay}%` }}
+              />
+            </div>
+            <span className="text-xs text-orange-500 w-12 text-right">
+              {row.percentOfDay.toFixed(1)}%
+            </span>
+          </div>
+
+          {/* 셋째 줄: 전체 기록 대비 */}
+          <div className="flex items-center space-x-2">
+            <span className="text-xs text-yellow-500 w-24">전체 기록 대비</span>
+            <div className="flex-1 h-3 bg-gray-200 rounded-full overflow-hidden">
+              <div
+                className="h-3 bg-yellow-500"
+                style={{ width: `${row.percentOfTotal}%` }}
+              />
+            </div>
+            <span className="text-xs text-yellow-500 w-12 text-right">
+              {row.percentOfTotal.toFixed(1)}%
+            </span>
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/app/stats/components/PlanVsLogStats.tsx
+++ b/src/app/stats/components/PlanVsLogStats.tsx
@@ -1,0 +1,126 @@
+"use client";
+
+import { useMemo } from "react";
+import { useActivityStore } from "@/stores/useActivityStore";
+import { parse, differenceInMinutes } from "date-fns";
+import { TIME_FMT } from "@/utils/constants";
+
+export default function PlanVsLogStats() {
+  const { activityList } = useActivityStore();
+
+  // 계획(plan)만 필터링
+  const plans = useMemo(
+    () => activityList.filter((a) => a.source === "plan"),
+    [activityList]
+  );
+
+  // 기록(log)만 필터링
+  const logs = useMemo(
+    () => activityList.filter((a) => a.source === "log" && a.endTime),
+    [activityList]
+  );
+
+  // 활동별 계획 총 시간 계산
+  const planMap = useMemo(() => {
+    const map = new Map<string, number>();
+    plans.forEach((plan) => {
+      if (!plan.endTime) return;
+
+      const mins = differenceInMinutes(
+        parse(plan.endTime, TIME_FMT, new Date()),
+        parse(plan.startTime, TIME_FMT, new Date())
+      );
+      if (mins <= 0) return;
+      map.set(plan.activityName, (map.get(plan.activityName) ?? 0) + mins);
+    });
+    return map;
+  }, [plans]);
+
+  // 활동별 기록 총 시간 계산
+  const logMap = useMemo(() => {
+    const map = new Map<string, number>();
+    logs.forEach((log) => {
+      if (!log.endTime) return;
+
+      const mins = differenceInMinutes(
+        parse(log.endTime, TIME_FMT, new Date()),
+        parse(log.startTime, TIME_FMT, new Date())
+      );
+      if (mins <= 0) return;
+      map.set(log.activityName, (map.get(log.activityName) ?? 0) + mins);
+    });
+    return map;
+  }, [logs]);
+
+  // Plan 대비 Log 계산 (계획이 없는 활동 제외)
+  const grouped = useMemo(() => {
+    const activities = Array.from(
+      new Set([...planMap.keys(), ...logMap.keys()])
+    );
+    return activities
+
+      .map((name) => {
+        const planMinutes = planMap.get(name) ?? 0;
+        const logMinutes = logMap.get(name) ?? 0;
+        const percent = (logMinutes / planMinutes) * 100;
+
+        if (planMinutes <= 0) return null; // 계획이 없는 활동 제외
+
+        return {
+          name,
+          planMinutes,
+          logMinutes,
+          percentOfPlan: percent,
+        };
+      })
+      .filter(
+        (
+          x
+        ): x is {
+          name: string;
+          planMinutes: number;
+          logMinutes: number;
+          percentOfPlan: number;
+        } => !!x
+      );
+  }, [planMap, logMap]);
+
+  // 달성률 색상
+  const getBarColor = (percent: number) => {
+    if (percent < 50) return "bg-red-500";
+    if (percent < 80) return "bg-orange-500";
+    if (percent <= 100) return "bg-green-500";
+    return "bg-green-700";
+  };
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-lg font-bold">계획 대비 기록</h2>
+
+      {grouped.map((row) => (
+        <div
+          key={row.name}
+          className="p-3 border rounded-xl shadow-sm bg-white space-y-1"
+        >
+          {/* 첫 줄: 이름 | 계획시간 / 실제시간 | 달성률 % */}
+          <div className="flex justify-between items-center mb-1 text-sm">
+            <span className="font-semibold">{row.name}</span>
+            <span>
+              {Math.floor(row.planMinutes / 60)}h {row.planMinutes % 60}m /{" "}
+              {Math.floor(row.logMinutes / 60)}h {row.logMinutes % 60}m
+            </span>
+            <span className="font-medium">{row.percentOfPlan.toFixed(1)}%</span>
+          </div>
+
+          {/* 둘째 줄: 진행 바 */}
+          <div className="h-3 bg-gray-200 rounded-full overflow-hidden">
+            <div
+              className={`h-3 ${getBarColor(row.percentOfPlan)}`}
+              style={{ width: `${Math.min(row.percentOfPlan, 100)}%` }}
+            />
+          </div>
+        </div>
+      ))}
+    </div>
+  );
+}

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { useState } from "react";
+import PlanStats from "./components/PlanStats";
+import LogStats from "./components/LogStats";
+import PlanVsLogStats from "./components/PlanVsLogStats";
+
+const Stats = () => {
+  const [activeTab, setActiveTab] = useState<"plan" | "log" | "planVsLog">(
+    "plan"
+  );
+
+  const tabs = [
+    { key: "plan", label: "계획" },
+    { key: "log", label: "기록" },
+    { key: "planVsLog", label: "계획 대비 기록" },
+  ] as const;
+
+  return (
+    <div className="max-w-3xl mx-auto p-4">
+      {/* 탭 버튼 */}
+      <div className="flex">
+        {tabs.map((tab) => (
+          <button
+            key={tab.key}
+            className={`flex-1 p-2 rounded-t-lg font-medium ${
+              activeTab === tab.key
+                ? "bg-white border-2 border-b-0"
+                : "bg-gray-200 text-gray-700 border-b-2"
+            }`}
+            onClick={() => setActiveTab(tab.key)}
+          >
+            {tab.label}
+          </button>
+        ))}
+      </div>
+
+      {/* 탭 컨텐츠 */}
+      <div className="border-2 border-t-0 rounded-b-2xl p-4 h-[500px] sm:h-[740px] overflow-y-auto">
+        {activeTab === "plan" && <PlanStats />}
+        {activeTab === "log" && <LogStats />}
+        {activeTab === "planVsLog" && <PlanVsLogStats />}
+      </div>
+    </div>
+  );
+};
+
+export default Stats;

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,2 @@
+export const TIME_FMT = "HH : mm : ss";
+export const DAY_MINUTES = 24 * 60;


### PR DESCRIPTION
## 📌 작업
 - 활동 통계 페이지 구현
## 🚀 작업 상세
 - 통계 버튼 누르면 통계 페이지 (/stats) 이동
 - 계획(plan), 기록(log), 계획 대비 기록 (plan vs log) 탭 구현
 - 계획과 기록은 24시간 기준과 총 활동 시간 기준으로 통계를 보여줌
 
## 🔗 스크린샷
<img width="1920" height="959" alt="screencapture-localhost-3000-stats-2025-08-28-19_31_54" src="https://github.com/user-attachments/assets/20de30ba-343e-4c15-832c-66992b3a7b46" />
