### PR TITLE
Feature/daily reset

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,5 +1,4 @@
 import CircularTimeline from "@/components/CircularTimeline/CircularTimeline";
-import ActivityStats from "@/components/ActivityStats";
 import ActivityBoard from "@/components/ActivityBoard/ActivityBoard";
 import ActivityList from "@/components/ActivityList/ActivityList";
 
@@ -13,7 +12,6 @@ function HomePage() {
       <section className="md:w-1/2 flex flex-col gap-4 p-4 pb-[100px] md:pb-[20px] md:overflow-y-auto">
         <ActivityList />
         <ActivityBoard />
-        {/* <ActivityStats /> */}
       </section>
     </main>
   );

--- a/src/app/stats/components/ActivityStats.tsx
+++ b/src/app/stats/components/ActivityStats.tsx
@@ -2,7 +2,7 @@
 
 import ActivityStatsHeader from "./ActivityStatsHeader";
 import ActivityStatItem from "./ActivityStatsItem";
-import { useGroupedActivities } from "@/hooks/useGroupedActivities";
+import useGroupedActivities from "@/hooks/useGroupedActivities";
 
 interface ActivityStatsProps {
   source: "plan" | "log";

--- a/src/app/stats/components/PlanVsLogStats.tsx
+++ b/src/app/stats/components/PlanVsLogStats.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useGroupedActivities } from "@/hooks/useGroupedActivities";
+import useGroupedActivities from "@/hooks/useGroupedActivities";
 import PlanVsLogStatsHeader from "./PlanVsLogStatsHeader";
 
 export default function PlanVsLogStats() {

--- a/src/components/ActivityBoard/ActivityLogger/ActivityLogger.tsx
+++ b/src/components/ActivityBoard/ActivityLogger/ActivityLogger.tsx
@@ -7,9 +7,12 @@ import { useActivityStore } from "@/stores/useActivityStore";
 import ActionButton from "@/components/ActivityBoard/ActionButton";
 import CurrentTime from "./CurrentTime";
 import ElapsedTime from "./ElapsedTime";
+import { useResetHour } from "@/hooks/useResetHour";
+import { getTodayKey } from "@/utils/getTodayKey";
 
 const ActivityLogger = () => {
   const [activityName, setActivityName] = useState("");
+  const { resetHour } = useResetHour();
   const { runningActivity, setRunningActivity, addActivity, updateActivity } =
     useActivityStore();
 
@@ -21,7 +24,7 @@ const ActivityLogger = () => {
       id: Date.now().toString(),
       activityName,
       startTime: getCurrentTime(),
-      date: new Date().toISOString().split("T")[0], // 현재 날짜 (YYYY-MM-DD)
+      date: getTodayKey(resetHour),
       source: "log",
     };
 

--- a/src/components/ActivityBoard/ActivityLogger/ActivityLogger.tsx
+++ b/src/components/ActivityBoard/ActivityLogger/ActivityLogger.tsx
@@ -21,6 +21,7 @@ const ActivityLogger = () => {
       id: Date.now().toString(),
       activityName,
       startTime: getCurrentTime(),
+      date: new Date().toISOString().split("T")[0], // 현재 날짜 (YYYY-MM-DD)
       source: "log",
     };
 

--- a/src/components/ActivityBoard/ActivityLogger/CurrentTime.tsx
+++ b/src/components/ActivityBoard/ActivityLogger/CurrentTime.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useCurrentTime } from "@/hooks/useCurrentTime";
+import useCurrentTime from "@/hooks/useCurrentTime";
 
 const CurrentTime = () => {
   const currentTime = useCurrentTime(); // 현재 시간 (HH : MM : SS)

--- a/src/components/ActivityBoard/ActivityLogger/ElapsedTime.tsx
+++ b/src/components/ActivityBoard/ActivityLogger/ElapsedTime.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useElapsedTime } from "@/hooks/useElapsedTime";
+import useElapsedTime from "@/hooks/useElapsedTime";
 import { formatElapsed } from "@/utils/formatElapsed";
 import { Activity } from "@/types/Activity";
 

--- a/src/components/ActivityBoard/ActivityPlanner/ActivityPlanner.tsx
+++ b/src/components/ActivityBoard/ActivityPlanner/ActivityPlanner.tsx
@@ -21,6 +21,7 @@ function ActivityPlanner() {
       activityName,
       startTime: toHMS(startTime),
       endTime: toHMS(endTime),
+      date: new Date().toISOString().split("T")[0], // 현재 날짜 (YYYY-MM-DD)
       source: "plan", // ActivityPlanner에서 추가된 활동은 "plan"으로 설정
     };
 

--- a/src/components/ActivityBoard/ActivityPlanner/ActivityPlanner.tsx
+++ b/src/components/ActivityBoard/ActivityPlanner/ActivityPlanner.tsx
@@ -5,12 +5,15 @@ import { Activity } from "@/types/Activity";
 import ActionButton from "../ActionButton";
 import { useActivityStore } from "@/stores/useActivityStore";
 import { toHMS } from "@/utils/toHMS";
+import { getTodayKey } from "@/utils/getTodayKey";
+import { useResetHour } from "@/hooks/useResetHour";
 
 function ActivityPlanner() {
   const [activityName, setActivityName] = useState("");
   const [startTime, setStartTime] = useState("");
   const [endTime, setEndTime] = useState("");
   const { addActivity } = useActivityStore();
+  const { resetHour } = useResetHour();
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
@@ -21,7 +24,7 @@ function ActivityPlanner() {
       activityName,
       startTime: toHMS(startTime),
       endTime: toHMS(endTime),
-      date: new Date().toISOString().split("T")[0], // 현재 날짜 (YYYY-MM-DD)
+      date: getTodayKey(resetHour),
       source: "plan", // ActivityPlanner에서 추가된 활동은 "plan"으로 설정
     };
 

--- a/src/components/ActivityList/ActivityList.tsx
+++ b/src/components/ActivityList/ActivityList.tsx
@@ -10,11 +10,13 @@ import RowItem from "./RowItem";
 import ActivityFilter from "./ActivityFilter";
 import TodoInput from "./TodoInput";
 import { TIME_FMT } from "@/utils/constants";
+import useTodayActivities from "@/hooks/useTodayActivities";
 
 const ActivityList = () => {
   const [filter, setFilter] = useState<"All" | "Todo" | "Plan" | "Log">("All");
-  const { activityList, removeActivity } = useActivityStore();
+  const { removeActivity } = useActivityStore();
   const { todos, addTodo, removeTodo } = useTodoStore();
+  const activityList = useTodayActivities(); // 오늘의 활동들
 
   const rows: Row[] = useMemo(() => {
     const todoRows: Row[] = todos.map((t) => ({

--- a/src/components/ActivityList/ActivityList.tsx
+++ b/src/components/ActivityList/ActivityList.tsx
@@ -11,6 +11,7 @@ import ActivityFilter from "./ActivityFilter";
 import TodoInput from "./TodoInput";
 import { TIME_FMT } from "@/utils/constants";
 import useTodayActivities from "@/hooks/useTodayActivities";
+import { LucideTimerReset } from "lucide-react";
 
 const ActivityList = () => {
   const [filter, setFilter] = useState<"All" | "Todo" | "Plan" | "Log">("All");

--- a/src/components/CircularTimeline/CircularTimeline.tsx
+++ b/src/components/CircularTimeline/CircularTimeline.tsx
@@ -5,6 +5,8 @@ import TimelineActivity from "./TimelineActivity";
 import TimelineRunner from "./TimelineRunner";
 import { polarToCartesian } from "@/utils/timeLine";
 import useTodayActivities from "@/hooks/useTodayActivities";
+import { useResetHour } from "@/hooks/useResetHour";
+import { LucideTimerReset } from "lucide-react";
 
 const SIZE = 500; // SVG 크기
 const r = SIZE / 2 - 50; // 반지름
@@ -14,6 +16,7 @@ const cy = SIZE / 2;
 const CircularTimeline = () => {
   const [currentMinutes, setCurrentMinutes] = useState<number | null>(null);
   const [hoveredPath, setHoveredPath] = useState<string | null>(null);
+  const { resetHour, setResetHour } = useResetHour();
   const activityList = useTodayActivities(); // 오늘의 활동들
 
   useEffect(() => {
@@ -68,17 +71,32 @@ const CircularTimeline = () => {
       {Array.from({ length: 24 }).map((_, i) => {
         const pos = polarToCartesian(cx, cy, i * 60, r + 20);
         return (
-          <text
-            key={i}
-            x={pos.x}
-            y={pos.y}
-            textAnchor="middle"
-            alignmentBaseline="middle"
-            fontSize="10"
-            fill="#000"
-          >
-            {i}
-          </text>
+          <g key={i}>
+            <text
+              x={pos.x}
+              y={pos.y}
+              textAnchor="middle"
+              alignmentBaseline="middle"
+              fontSize={10}
+              fill="#000"
+              fontWeight="normal"
+              className="cursor-pointer fill-current hover:font-bold hover:text-red-500"
+              onClick={() => setResetHour(i)}
+            >
+              {i !== resetHour && i}
+            </text>
+
+            {i === resetHour && (
+              <foreignObject
+                x={pos.x - 12}
+                y={pos.y - 14}
+                width={25}
+                height={25}
+              >
+                <LucideTimerReset size={25} className="text-red-500" />
+              </foreignObject>
+            )}
+          </g>
         );
       })}
 

--- a/src/components/CircularTimeline/CircularTimeline.tsx
+++ b/src/components/CircularTimeline/CircularTimeline.tsx
@@ -1,10 +1,10 @@
 "use client";
 
 import { useEffect, useState } from "react";
-import { useActivityStore } from "@/stores/useActivityStore";
 import TimelineActivity from "./TimelineActivity";
 import TimelineRunner from "./TimelineRunner";
 import { polarToCartesian } from "@/utils/timeLine";
+import useTodayActivities from "@/hooks/useTodayActivities";
 
 const SIZE = 500; // SVG 크기
 const r = SIZE / 2 - 50; // 반지름
@@ -14,7 +14,7 @@ const cy = SIZE / 2;
 const CircularTimeline = () => {
   const [currentMinutes, setCurrentMinutes] = useState<number | null>(null);
   const [hoveredPath, setHoveredPath] = useState<string | null>(null);
-  const { activityList } = useActivityStore();
+  const activityList = useTodayActivities(); // 오늘의 활동들
 
   useEffect(() => {
     function getMinutes(date: Date) {

--- a/src/components/CircularTimeline/TimelineActivity.tsx
+++ b/src/components/CircularTimeline/TimelineActivity.tsx
@@ -29,8 +29,12 @@ export default function TimelineActivity({
     activity.source === "log" && !activity.endTime && currentMinutes !== null
       ? currentMinutes
       : parseTime(activity.endTime || activity.startTime);
-  const mid = (start + end) / 2;
-  const textPos = polarToCartesian(cx, cy, mid, r * 0.6);
+
+  const adjustedEnd = end < start ? end + 1440 : end;
+  const mid = (start + adjustedEnd) / 2;
+  const midMinutes = mid % 1440;
+
+  const textPos = polarToCartesian(cx, cy, midMinutes, r * 0.6);
 
   const fillColor =
     activity.source === "plan"

--- a/src/components/CircularTimeline/TimelineRunner.tsx
+++ b/src/components/CircularTimeline/TimelineRunner.tsx
@@ -22,6 +22,7 @@ export default function TimelineRunner({
 
   return (
     <g
+      className="pointer-events-none"
       transform={`rotate(${(runnerPosition.angle * 180) / Math.PI + 90}, ${
         runnerPosition.x
       }, ${runnerPosition.y})`}

--- a/src/hooks/useCurrentTime.ts
+++ b/src/hooks/useCurrentTime.ts
@@ -1,7 +1,7 @@
 import { getCurrentTime } from "@/utils/currentTime";
 import { useState, useEffect } from "react";
 
-export const useCurrentTime = (intervalSeconds = 1) => {
+const useCurrentTime = (intervalSeconds = 1) => {
   const [currentTime, setCurrentTime] = useState<string | null>(null);
 
   useEffect(() => {
@@ -15,3 +15,5 @@ export const useCurrentTime = (intervalSeconds = 1) => {
 
   return currentTime;
 };
+
+export default useCurrentTime;

--- a/src/hooks/useElapsedTime.ts
+++ b/src/hooks/useElapsedTime.ts
@@ -4,7 +4,7 @@ import { useState, useEffect } from "react";
 import { Activity } from "@/types/Activity";
 
 // Activity의 startTime을 받아서 경과 시간(초)을 반환
-export const useElapsedTime = (activity: Activity | null) => {
+const useElapsedTime = (activity: Activity | null) => {
   const [elapsedSec, setElapsedSec] = useState(0);
 
   useEffect(() => {
@@ -31,3 +31,5 @@ export const useElapsedTime = (activity: Activity | null) => {
 
   return elapsedSec;
 };
+
+export default useElapsedTime;

--- a/src/hooks/useGroupedActivities.ts
+++ b/src/hooks/useGroupedActivities.ts
@@ -1,10 +1,10 @@
 import { useMemo } from "react";
-import { useActivityStore } from "@/stores/useActivityStore";
 import { parse, differenceInMinutes } from "date-fns";
 import { DAY_MINUTES, TIME_FMT } from "@/utils/constants";
+import useTodayActivities from "./useTodayActivities";
 
-export function useGroupedActivities(source: "plan" | "log") {
-  const activityList = useActivityStore((state) => state.activityList);
+const useGroupedActivities = (source: "plan" | "log") => {
+  const activityList = useTodayActivities();
 
   return useMemo(() => {
     const filtered = activityList.filter(
@@ -36,4 +36,6 @@ export function useGroupedActivities(source: "plan" | "log") {
       grouped,
     };
   }, [activityList, source]);
-}
+};
+
+export default useGroupedActivities;

--- a/src/hooks/useResetHour.ts
+++ b/src/hooks/useResetHour.ts
@@ -1,0 +1,21 @@
+"use client";
+
+import { useState, useEffect } from "react";
+
+export function useResetHour() {
+  const [resetHour, setResetHour] = useState<number>(0);
+  const [ready, setReady] = useState(false);
+
+  useEffect(() => {
+    const saved = localStorage.getItem("resetHour");
+    if (saved) setResetHour(parseInt(saved));
+    setReady(true);
+  }, []);
+
+  useEffect(() => {
+    if (!ready) return;
+    localStorage.setItem("resetHour", resetHour.toString());
+  }, [resetHour, ready]);
+
+  return { resetHour, setResetHour };
+}

--- a/src/hooks/useTodayActivities.ts
+++ b/src/hooks/useTodayActivities.ts
@@ -1,10 +1,72 @@
+import { useEffect, useState } from "react";
 import { useActivityStore } from "@/stores/useActivityStore";
+import { useResetHour } from "./useResetHour";
+import { getTodayKey } from "@/utils/getTodayKey";
 
 const useTodayActivities = () => {
+  const { resetHour } = useResetHour();
   const activityList = useActivityStore((s) => s.activityList);
-  const todayKey = new Date().toISOString().split("T")[0];
+  const [todayKey, setTodayKey] = useState(getTodayKey(resetHour));
+
+  useEffect(() => {
+    setTodayKey(getTodayKey(resetHour));
+
+    const interval = setInterval(() => {
+      setTodayKey(getTodayKey(resetHour));
+    }, 60 * 1000); // 1분마다 체크
+    return () => clearInterval(interval);
+  }, [resetHour]);
 
   return activityList.filter((a) => a.date === todayKey);
 };
 
 export default useTodayActivities;
+
+// setTimeout 방식
+// "use client";
+
+// import { useState, useEffect, useRef } from "react";
+// import { useActivityStore } from "@/stores/useActivityStore";
+// import { useResetHour } from "./useResetHour";
+// import { getTodayKey } from "@/utils/getTodayKey";
+
+// const useTodayActivities = () => {
+//   const { resetHour } = useResetHour();
+//   const activityList = useActivityStore((s) => s.activityList);
+
+//   // 초기 todayKey
+//   const [todayKey, setTodayKey] = useState(getTodayKey(resetHour));
+//   const timeoutRef = useRef<NodeJS.Timeout | null>(null);
+
+//   useEffect(() => {
+//     function scheduleNextReset() {
+//       // 남은 시간 계산
+//       const now = new Date();
+//       const nextReset = new Date(now);
+//       nextReset.setHours(resetHour, 0, 0, 0);
+
+//       if (nextReset <= now) {
+//         // 이미 resetHour가 지났다면 내일로
+//         nextReset.setDate(nextReset.getDate() + 1);
+//       }
+
+//       const delay = nextReset.getTime() - now.getTime();
+
+//       // 예약
+//       timeoutRef.current = setTimeout(() => {
+//         setTodayKey(getTodayKey(resetHour));
+//         scheduleNextReset(); // 다음 날도 예약
+//       }, delay);
+//     }
+
+//     scheduleNextReset();
+
+//     return () => {
+//       if (timeoutRef.current) clearTimeout(timeoutRef.current);
+//     };
+//   }, [resetHour]);
+
+//   return activityList.filter((a) => a.date === todayKey);
+// };
+
+// export default useTodayActivities;

--- a/src/hooks/useTodayActivities.ts
+++ b/src/hooks/useTodayActivities.ts
@@ -1,0 +1,10 @@
+import { useActivityStore } from "@/stores/useActivityStore";
+
+const useTodayActivities = () => {
+  const activityList = useActivityStore((s) => s.activityList);
+  const todayKey = new Date().toISOString().split("T")[0];
+
+  return activityList.filter((a) => a.date === todayKey);
+};
+
+export default useTodayActivities;

--- a/src/types/Activity.ts
+++ b/src/types/Activity.ts
@@ -3,5 +3,6 @@ export interface Activity {
   activityName: string; // 활동 이름
   startTime: string; // 시작 시간 (HH:mm)
   endTime?: string; // 종료 시간 (HH:mm)
+  date: string; // 활동 날짜 (YYYY-MM-DD)
   source: "plan" | "log"; // 계획 또는 기록
 }

--- a/src/utils/getTodayKey.ts
+++ b/src/utils/getTodayKey.ts
@@ -1,0 +1,10 @@
+export const getTodayKey = (resetHour: number) => {
+  const now = new Date();
+  now.setHours(now.getHours() - resetHour);
+
+  const year = now.getFullYear();
+  const month = String(now.getMonth() + 1).padStart(2, "0");
+  const date = String(now.getDate()).padStart(2, "0");
+
+  return `${year}-${month}-${date}`;
+};


### PR DESCRIPTION
## 📌 작업
 - 초기화 시간 구현 및 설정
## 🚀 작업 상세
- Activity 타입에 날짜(date) 추가
- Activity 리스트에서 오늘 날짜만 필터링하여 랜더링
- resetHour 기준으로 하루를 구분하고, 초기화 시간이 지나면 오늘 활동(todayKey)을 새로 계산
- useTodayActivities 커스텀 훅을 만들어 resetHour와 activityList를 기반으로 오늘 활동 필터링
- CircularTimeline, ActivityList 등 UI 컴포넌트에서 새로 계산된 todayKey를 기준으로 렌더링
- localStorage를 사용해 비회원이라도 설정한 resetHour 유지
- 1분 간격 인터벌로 todayKey 갱신 -> 추후 setTimeout으로 남은 시간 계산하여  resetHour 시각에 todayKey 자동 갱신 필요

## 🔗 스크린샷
<img width="1920" height="959" alt="screencapture-localhost-3000-2025-08-30-04_28_26" src="https://github.com/user-attachments/assets/1ef4bd3d-7b74-4d3e-aba8-351709684b2b" />
