### PR TITLE
refactor/랜딩페이지 md 이상 레이아웃 개선

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,7 +16,7 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
-      <body>
+      <body className="flex flex-col min-h-screen">
         <LayoutWrapper>{children}</LayoutWrapper>
         <ModalManager />
       </body>

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,18 +4,18 @@ import ActivityRender from "@/components/ActivityRender/AcitivityRender";
 
 function HomePage() {
   return (
-    <main className="flex flex-col md:flex-row">
-      <section className="md:w-1/2">
+    <div className="flex flex-col md:flex-row h-[calc(100vh-88px-58px)]">
+      <section className="md:w-1/2 flex items-center justify-center">
         <ActivityRender />
       </section>
 
       <section className="md:w-1/2 flex flex-col gap-4 p-4">
-        <div className="hidden md:block">
+        <div className="hidden md:block flex-grow">
           <ActivityList />
         </div>
         <ActivityBoard />
       </section>
-    </main>
+    </div>
   );
 }
 

--- a/src/components/ActivityList/ActivityList.tsx
+++ b/src/components/ActivityList/ActivityList.tsx
@@ -96,7 +96,7 @@ const ActivityList = () => {
   }, [todos, activityList, filter, removeActivity, removeTodo]);
 
   return (
-    <div className="w-full mx-auto p-4 bg-white shadow-lg border-2 rounded-2xl h-[360px] md:h-[480px] overflow-y-auto">
+    <div className="w-full mx-auto p-4 bg-white shadow-lg border-2 rounded-2xl h-full overflow-y-auto">
       <h2 className="hidden md:block text-xl font-bold mb-4">
         할 일 / 활동 목록
       </h2>

--- a/src/components/ActivityRender/AcitivityRender.tsx
+++ b/src/components/ActivityRender/AcitivityRender.tsx
@@ -8,9 +8,9 @@ function ActivityRender() {
   const [activeTab, setActiveTab] = useState<"timeline" | "list">("timeline");
 
   return (
-    <div className="w-full">
+    <>
       {/* md 이상에서는 CircularTimeline만 */}
-      <div className="hidden md:block md:h-[820px]">
+      <div className="hidden md:block h-full">
         <CircularTimeline />
       </div>
 
@@ -49,7 +49,7 @@ function ActivityRender() {
           )}
         </div>
       </div>
-    </div>
+    </>
   );
 }
 

--- a/src/components/CircularTimeline/CircularTimeline.tsx
+++ b/src/components/CircularTimeline/CircularTimeline.tsx
@@ -44,7 +44,7 @@ const CircularTimeline = () => {
   }
 
   return (
-    <svg className="w-full h-full" viewBox={`0 0 ${SIZE} ${SIZE}`}>
+    <svg className="h-full w-full" viewBox={`0 0 ${SIZE} ${SIZE}`}>
       {/* 배경 원 */}
       <circle
         cx={cx}

--- a/src/components/Layout/Footer.tsx
+++ b/src/components/Layout/Footer.tsx
@@ -21,7 +21,7 @@ function Footer() {
   ];
 
   return (
-    <footer className="fixed bottom-0 w-full p-4 border-t-2 bg-white shadow flex justify-around">
+    <footer className="p-4 border-t-2 bg-white shadow flex justify-around">
       {navMenu.map((item) => (
         <Link
           key={item.name}

--- a/src/components/Layout/Header.tsx
+++ b/src/components/Layout/Header.tsx
@@ -19,7 +19,7 @@ function Header() {
   }, []);
 
   return (
-    <header className="sticky top-0 w-full px-4 py-1 sm:px-10 bg-white shadow flex justify-between items-center">
+    <header className="px-4 py-1 sm:px-10 bg-white shadow flex justify-between items-center">
       <h1 className="relative text-xl font-bold">
         <Link href="/" className="block  w-40 h-16 sm:w-48 sm:h-20">
           <Image

--- a/src/components/Layout/LayoutWrapper.tsx
+++ b/src/components/Layout/LayoutWrapper.tsx
@@ -15,7 +15,7 @@ export default function LayoutWrapper({ children }: LayoutWrapperProps) {
   return (
     <>
       {!hideLayout && <Header />}
-      {children}
+      <main className="flex-grow">{children}</main>
       {!hideLayout && <Footer />}
     </>
   );


### PR DESCRIPTION
## 📌 작업
 - 랜딩페이지 md 이상 레이아웃 개선
## 🚀 작업 상세
 - 브라우저 창 높이가 달라질 때를 고려하여 main 영역의 높이를 h-[calc(100vh-88px-58px)] 로 개선 (브라우저 창 - 헤더 - 푸터)
## 🔗 스크린샷
<img width="1920" height="919" alt="screencapture-localhost-3000-2025-09-06-17_36_20" src="https://github.com/user-attachments/assets/f982d717-a1a6-4e70-9414-6622b29eba2a" />
