### PR TITLE
Feature/layout

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,8 +4,8 @@ import ActivityRender from "@/components/ActivityRender/AcitivityRender";
 
 function HomePage() {
   return (
-    <div className="flex flex-col md:flex-row h-full">
-      <section className="md:w-1/2 flex items-center justify-center">
+    <div className="flex flex-col md:flex-row h-full overflow-auto">
+      <section className="h-full md:w-1/2 flex items-center justify-center">
         <ActivityRender />
       </section>
 

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -4,7 +4,7 @@ import ActivityRender from "@/components/ActivityRender/AcitivityRender";
 
 function HomePage() {
   return (
-    <div className="flex flex-col md:flex-row h-[calc(100vh-88px-58px)]">
+    <div className="flex flex-col md:flex-row h-full">
       <section className="md:w-1/2 flex items-center justify-center">
         <ActivityRender />
       </section>

--- a/src/app/stats/layout.tsx
+++ b/src/app/stats/layout.tsx
@@ -11,5 +11,7 @@ export default function StatsLayout({
 }: {
   children: React.ReactNode;
 }) {
-  return <div className="max-w-3xl mx-auto p-4 bg-white">{children}</div>;
+  return (
+    <div className="flex flex-col max-w-3xl mx-auto p-4 h-full">{children}</div>
+  );
 }

--- a/src/app/stats/page.tsx
+++ b/src/app/stats/page.tsx
@@ -35,7 +35,7 @@ const Stats = () => {
       </div>
 
       {/* 탭 컨텐츠 */}
-      <div className="border-2 border-t-0 rounded-b-2xl p-4 h-[540px] sm:h-[740px] overflow-y-auto">
+      <div className="flex flex-col border-2 border-t-0 rounded-b-2xl p-4 h-full overflow-y-auto">
         {activeTab === "plan" && <ActivityStats source="plan" />}
         {activeTab === "log" && <ActivityStats source="log" />}
         {activeTab === "planVsLog" && <PlanVsLogStats />}

--- a/src/components/ActivityRender/AcitivityRender.tsx
+++ b/src/components/ActivityRender/AcitivityRender.tsx
@@ -10,13 +10,13 @@ function ActivityRender() {
   return (
     <>
       {/* md 이상에서는 CircularTimeline만 */}
-      <div className="hidden md:block h-full">
+      <div className="hidden md:block h-full w-full">
         <CircularTimeline />
       </div>
 
       {/* md 이하에서는 탭 UI */}
-      <div className="block md:hidden">
-        <div className="flex border-b border-gray-300 mb-2">
+      <div className="block md:hidden h-full w-full">
+        <div className="flex border-b border-gray-300">
           <button
             className={`flex-1 p-2 text-center font-semibold cursor-pointer ${
               activeTab === "timeline"

--- a/src/components/Layout/LayoutWrapper.tsx
+++ b/src/components/Layout/LayoutWrapper.tsx
@@ -15,7 +15,7 @@ export default function LayoutWrapper({ children }: LayoutWrapperProps) {
   return (
     <>
       {!hideLayout && <Header />}
-      <main className="flex-grow">{children}</main>
+      <main className="h-[calc(100vh-var(--hh)-var(--fh))]">{children}</main>
       {!hideLayout && <Footer />}
     </>
   );

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -3,6 +3,8 @@
 :root {
   --background: #ffffff;
   --foreground: #171717;
+  --hh: 88px; /* header height */
+  --fh: 58px; /* footer height */
 }
 
 @theme inline {
@@ -12,12 +14,11 @@
   --font-mono: var(--font-geist-mono);
 }
 
-/* @media (prefers-color-scheme: dark) {
+@media (max-width: 640px) {
   :root {
-    --background: #0a0a0a;
-    --foreground: #ededed;
+    --hh: 72px;
   }
-} */
+}
 
 body {
   background: var(--background);


### PR DESCRIPTION
## 📌 작업
 - 랜딩, 통계 페이지 레이아웃 개선 
## 🚀 작업 상세
 - 랜딩 페이지 타임라인 sm 이하에서 너비 다 채우도록 수정
 - 통계 페이지 비어있을때에도 main 높이 차지하도록 수정
 - 글로벌 css에 헤더 높이, 푸터 높이 지정하여 main 높이 산출
## 🔗 스크린샷
<img width="1920" height="959" alt="screencapture-localhost-3000-stats-2025-09-07-23_58_18" src="https://github.com/user-attachments/assets/1469a12e-9dd9-4f9b-a8f3-52e0243c6838" />
