### PR TITLE
refactor/폰크기 활동목록 크기 수정

### DIFF
--- a/src/components/ActivityList/ActivityList.tsx
+++ b/src/components/ActivityList/ActivityList.tsx
@@ -96,7 +96,7 @@ const ActivityList = () => {
   }, [todos, activityList, filter, removeActivity, removeTodo]);
 
   return (
-    <div className="w-full mx-auto p-4 bg-white shadow-lg border-2 rounded-2xl h-full overflow-y-auto">
+    <div className="w-full mx-auto p-2 bg-white shadow-lg border-2 rounded-2xl h-full overflow-y-auto">
       <h2 className="hidden md:block text-xl font-bold mb-4">
         할 일 / 활동 목록
       </h2>

--- a/src/components/ActivityRender/AcitivityRender.tsx
+++ b/src/components/ActivityRender/AcitivityRender.tsx
@@ -15,7 +15,7 @@ function ActivityRender() {
       </div>
 
       {/* md 이하에서는 탭 UI */}
-      <div className="block md:hidden h-full w-full">
+      <div className="flex flex-col md:hidden h-full w-full">
         <div className="flex border-b border-gray-300">
           <button
             className={`flex-1 p-2 text-center font-semibold cursor-pointer ${
@@ -39,11 +39,11 @@ function ActivityRender() {
           </button>
         </div>
 
-        <div className="mt-2">
+        <div className="mt-2 flex flex-col flex-1">
           {activeTab === "timeline" ? (
             <CircularTimeline />
           ) : (
-            <div className="px-4">
+            <div className="px-2 h-full">
               <ActivityList />
             </div>
           )}


### PR DESCRIPTION
## 📌 작업
 - 폰 크기 일 때, 활동 랜더링 영역 차지 개선
## 🚀 작업 상세
 - 활동 목록 비었을 때에도 꽉 차도록 수정
## 🔗 스크린샷

<img width="360" height="740" alt="screencapture-localhost-3000-2025-09-08-01_45_09 (1)" src="https://github.com/user-attachments/assets/4cdc916b-b15e-43fc-b3b6-4e85ae3d8d7a" />
